### PR TITLE
Feat: Add PyInstaller packaging and standalone executable build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ test_recording.wav
 # OS specific
 .DS_Store
 Thumbs.db
+
+# Build artifacts
+build/
+dist/
+*.spec

--- a/build.py
+++ b/build.py
@@ -1,0 +1,17 @@
+import PyInstaller.__main__
+import customtkinter
+import os
+
+# Get path to customtkinter to bundle its data (themes, fonts, etc.)
+customtkinter_path = os.path.dirname(customtkinter.__file__)
+
+PyInstaller.__main__.run([
+    'main.py',
+    '--name=Talkie',
+    '--noconsole',
+    '--onefile',
+    f'--add-data={customtkinter_path};customtkinter/',
+    '--collect-all=sounddevice',
+    '--collect-all=soundfile',
+    '--clean'
+])

--- a/modules/audio_io.py
+++ b/modules/audio_io.py
@@ -1,11 +1,17 @@
 import os
+import sys
 import numpy as np
 import soundfile as sf
 import sounddevice as sd
 import threading
 import queue
 
-ASSETS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'assets')
+def get_base_dir():
+    if getattr(sys, 'frozen', False):
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+ASSETS_DIR = os.path.join(get_base_dir(), 'assets')
 START_WAV = os.path.join(ASSETS_DIR, 'start.wav')
 STOP_WAV = os.path.join(ASSETS_DIR, 'stop.wav')
 SAMPLE_RATE = 44100

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -1,7 +1,13 @@
 import json
 import os
+import sys
 
-CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'config.json')
+def get_base_dir():
+    if getattr(sys, 'frozen', False):
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+CONFIG_FILE = os.path.join(get_base_dir(), 'config.json')
 
 DEFAULT_CONFIG = {
     "api_provider": "openai",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Pillow
 requests
 python-dotenv
 uiautomation
+pyinstaller


### PR DESCRIPTION
This PR adds a build script and updates path resolution to allow Talkie to be packaged as a single, portable Windows executable.