### PR TITLE
fix(hotkey): per-key suppression to fix text injection

### DIFF
--- a/talkie_modules/hotkey_manager.py
+++ b/talkie_modules/hotkey_manager.py
@@ -1,5 +1,6 @@
 """Global hotkey listener for Talkie."""
 
+import threading
 from typing import Callable, Optional
 
 import keyboard
@@ -10,7 +11,12 @@ logger = get_logger("hotkey")
 
 
 class HotkeyManager:
-    """Listens for a configurable hold-to-talk hotkey."""
+    """Listens for a configurable hold-to-talk hotkey.
+
+    Uses per-key suppression via ``keyboard.hook_key`` so that only the
+    trigger key's scan-codes are intercepted.  All other keys (including
+    synthetic Ctrl+V from pyautogui) pass through untouched.
+    """
 
     def __init__(
         self,
@@ -22,6 +28,7 @@ class HotkeyManager:
         self.on_press: Callable[[], None] = on_press
         self.on_release: Callable[[], None] = on_release
         self.is_held: bool = False
+        self._hook_handle: Optional[object] = None
 
         parts = self.hotkey.split("+")
         self.trigger_key: str = parts[-1].strip()
@@ -32,8 +39,14 @@ class HotkeyManager:
         """Check if event_name matches key, including left/right variants."""
         return event_name in (key, f"left {key}", f"right {key}")
 
-    def _on_key_event(self, event: keyboard.KeyboardEvent) -> Optional[bool]:
-        """Handle key events. Returns False to suppress OS-level side effects."""
+    def _on_trigger_key(self, event: keyboard.KeyboardEvent) -> Optional[bool]:
+        """Handle trigger key events.  Runs in the hook thread (synchronous).
+
+        Returns ``False`` to suppress the event, ``True`` to pass through.
+        Because we registered via ``hook_key``, this callback is only
+        invoked for the trigger key's scan-codes — other keys are never
+        affected.
+        """
         all_mods_pressed: bool = all(
             keyboard.is_pressed(mod)
             or keyboard.is_pressed(f"left {mod}")
@@ -41,35 +54,38 @@ class HotkeyManager:
             for mod in self.modifiers
         ) if self.modifiers else True
 
-        if self._matches_key(event.name, self.trigger_key):
-            if event.event_type == keyboard.KEY_DOWN:
-                if all_mods_pressed and not self.is_held:
-                    self.is_held = True
-                    logger.info("Hotkey pressed: %s", self.hotkey)
-                    if self.on_press:
-                        self.on_press()
-                # Suppress trigger key while modifiers held to prevent
-                # OS side effects (e.g. Windows key opening Start Menu)
-                if all_mods_pressed:
-                    return False
-            elif event.event_type == keyboard.KEY_UP:
-                if self.is_held:
-                    self.is_held = False
-                    logger.info("Hotkey released: %s", self.hotkey)
-                    if self.on_release:
-                        self.on_release()
-                    return False
-        return None
+        if event.event_type == keyboard.KEY_DOWN:
+            if all_mods_pressed and not self.is_held:
+                self.is_held = True
+                logger.info("Hotkey pressed: %s", self.hotkey)
+                if self.on_press:
+                    # Dispatch to thread — hook thread has ~300ms Windows timeout
+                    threading.Thread(target=self.on_press, daemon=True).start()
+            # Suppress trigger key while modifiers held to prevent
+            # OS side effects (e.g. Windows key opening Start Menu)
+            if all_mods_pressed:
+                return False
+        elif event.event_type == keyboard.KEY_UP:
+            if self.is_held:
+                self.is_held = False
+                logger.info("Hotkey released: %s", self.hotkey)
+                if self.on_release:
+                    threading.Thread(target=self.on_release, daemon=True).start()
+                return False
+        return True
 
     def start(self) -> None:
         """Start listening for the hotkey."""
-        keyboard.hook(self._on_key_event)
+        self._hook_handle = keyboard.hook_key(
+            self.trigger_key, self._on_trigger_key, suppress=True
+        )
         logger.info("Hotkey listener started: %s", self.hotkey)
 
     def stop(self) -> None:
         """Stop listening for the hotkey."""
         try:
-            keyboard.unhook(self._on_key_event)
+            if self._hook_handle:
+                keyboard.unhook_key(self._hook_handle)
             logger.info("Hotkey listener stopped")
         except (KeyError, ValueError):
             logger.debug("Hotkey was not hooked or already unhooked")


### PR DESCRIPTION
## Summary
- Replaced global `keyboard.hook(suppress=True)` with `keyboard.hook_key(trigger_key, ..., suppress=True)` so only the trigger key's scan codes are intercepted
- Synthetic Ctrl+V from pyautogui (used by `text_injector.py`) no longer gets corrupted by the blocking hook — fixes output being just spaces
- Dispatches `on_press`/`on_release` callbacks to daemon threads to avoid the ~300ms Windows hook thread timeout

## Test plan
- [x] All 33 pytest tests pass
- [x] Manual test: hold Ctrl+Win → start chime, no window snapping
- [x] Manual test: release → stop chime, no Start Menu
- [x] Manual test: transcribed text pastes correctly (not spaces)
- [ ] Verify Win key works normally without Ctrl held
- [ ] Verify all other keys unaffected (type in notepad, Ctrl+C/V)

🤖 Generated with [Claude Code](https://claude.com/claude-code)