### PR TITLE
ci(release): add manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and publish (e.g. v1.7.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -42,6 +48,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: |
             dist/Talkie.exe
             dist/SHA256SUMS.txt


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` trigger to the release workflow, alongside the existing tag-push trigger, so a release can be cut without pushing a tag directly.

- New `workflow_dispatch` input `tag` (e.g. `v1.7.0`).
- The `action-gh-release` step now sets `tag_name: ${{ github.event.inputs.tag || github.ref_name }}` — it uses the dispatch input when triggered manually (creating the tag at the built commit if it doesn't exist), and falls back to the pushed tag ref for the existing tag-push flow.

This is behavior-preserving for tag-push releases and enables triggering a build/publish via the Actions API.

## Testing

CI runs the test suite on this PR. The release workflow itself only runs on tag push / manual dispatch, so it is exercised by dispatching it after merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HgG1JVoJRdvpFjwtLXjakb)_